### PR TITLE
 Fix scheduler unable to find newly created rules without restart

### DIFF
--- a/modules/conditional_tags/routes.py
+++ b/modules/conditional_tags/routes.py
@@ -4,7 +4,7 @@ Routes for conditional tagging feature
 
 from flask import render_template, request, jsonify, redirect, url_for, send_file
 from . import conditional_tags_bp
-from .storage import RuleStorage, ExecutionHistory
+from .storage import ExecutionHistory, get_rule_storage
 from .engine import RuleEngine
 from .models import ConditionalRule, RuleConditionGroup, RuleAction, RuleSchedule
 from .scheduler import get_scheduler
@@ -19,7 +19,7 @@ from datetime import datetime, timezone
 logger = logging.getLogger(__name__)
 
 # Initialize components
-storage = RuleStorage()
+storage = get_rule_storage()
 history = ExecutionHistory()
 engine = RuleEngine()
 


### PR DESCRIPTION
Fix issue #12 : Scheduled rules not executing due to storage instance mismatch

- Implement singleton pattern for RuleStorage to ensure all components share the same instance
- Add automatic reload from disk when rule not found in memory
- Add comprehensive debug logging to track rule execution flow
- Fix scheduler unable to find newly created rules without restart

The issue was caused by multiple RuleStorage instances not sharing state between
the API routes and the scheduler. Now all components use a shared storage instance
that can reload from disk when needed.

Close #12 